### PR TITLE
Blog title tooltip

### DIFF
--- a/src/components/BlogSidebar.astro
+++ b/src/components/BlogSidebar.astro
@@ -115,8 +115,7 @@ const recentPosts = sortedPosts.slice(0, 5);
                 fill="none" 
                 stroke="currentColor" 
                 stroke-width="2" 
-                stroke-linecap="round" 
-                title={post.data.title}
+                stroke-linejoin="round"
               >
                 <polyline points="6 9 12 15 18 9"></polyline>
               </svg>

--- a/src/components/BlogSidebar.astro
+++ b/src/components/BlogSidebar.astro
@@ -136,7 +136,7 @@ const recentPosts = sortedPosts.slice(0, RECENT_POSTS_LIMIT);
                   data-post-title={post.data.title.toLowerCase()}
                   data-post-tags={post.data.tags.join(' ').toLowerCase()}
                   data-post-description={post.data.description.toLowerCase()}
-                  data-tooltip={post.data.title}
+                  title={post.data.title}
                 >
                   <div class="truncate font-medium">{post.data.title}</div>
                   <div class="text-xs text-secondary-400 mt-1">
@@ -396,83 +396,5 @@ const recentPosts = sortedPosts.slice(0, RECENT_POSTS_LIMIT);
   }
 
   /* Shared tooltip utility styles */
-  .tooltip-trigger {
-    position: relative;
-  }
-
-  .tooltip-trigger[data-tooltip]:hover::after {
-    content: attr(data-tooltip);
-    position: absolute;
-    top: 0;
-    left: 100%;
-    transform: translateX(12px);
-    background: linear-gradient(135deg, #1a1a1a, #0a0a0a);
-    color: #ffffff;
-    padding: 1rem 1.25rem;
-    border-radius: 0.5rem;
-    font-size: 1rem;
-    font-weight: 500;
-    z-index: 1000;
-    border: 1px solid #666666;
-    box-shadow: 
-      0 10px 25px -5px rgba(0, 0, 0, 0.4),
-      0 10px 10px -5px rgba(0, 0, 0, 0.2),
-      0 0 0 1px rgba(255, 255, 255, 0.05) inset;
-    pointer-events: none;
-    max-width: 400px;
-    white-space: normal;
-    text-align: left;
-    line-height: 1.4;
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
-    opacity: 0;
-    transform: translateX(8px) scale(0.95);
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-    animation: tooltipFadeIn 0.2s ease-out forwards;
-  }
-
-  .tooltip-trigger[data-tooltip]:hover::before {
-    content: '';
-    position: absolute;
-    top: 12px;
-    left: 100%;
-    transform: translateX(8px);
-    width: 0;
-    height: 0;
-    border-top: 4px solid transparent;
-    border-bottom: 4px solid transparent;
-    border-right: 6px solid #666666;
-    z-index: 1001;
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.2s ease-out 0.1s;
-    animation: tooltipArrowFadeIn 0.2s ease-out 0.1s forwards;
-  }
-
-  /* Apply tooltip styles to specific elements */
-  .post-link,
-  .recent-post-link {
-    position: relative;
-  }
-
-  @keyframes tooltipFadeIn {
-    from {
-      opacity: 0;
-      transform: translateX(8px) scale(0.95);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(12px) scale(1);
-    }
-  }
-
-  @keyframes tooltipArrowFadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
 </style>
 </aside>

--- a/src/components/BlogSidebar.astro
+++ b/src/components/BlogSidebar.astro
@@ -7,6 +7,9 @@ interface Props {
 
 const { currentSlug } = Astro.props;
 
+// Configuration constants
+const RECENT_POSTS_LIMIT = 3;
+
 // Get all blog posts from content collection
 const allBlogPosts = await getCollection('blog');
 
@@ -29,8 +32,8 @@ const postsByCategory = sortedPosts.reduce((acc, post) => {
 // Get all unique categories and sort them
 const categories = Object.keys(postsByCategory).sort();
 
-// Get recent posts (last 5)
-const recentPosts = sortedPosts.slice(0, 5);
+// Get recent posts (configurable limit)
+const recentPosts = sortedPosts.slice(0, RECENT_POSTS_LIMIT);
 ---
 
 <aside class="blog-sidebar w-80 flex-shrink-0 bg-secondary-950/50 backdrop-blur-sm border-r border-secondary-800 h-screen sticky top-0 overflow-y-auto lg:block hidden">
@@ -68,7 +71,7 @@ const recentPosts = sortedPosts.slice(0, 5);
               currentSlug === post.slug 
                 ? 'bg-accent-500/20 text-accent-400 border-l-2 border-accent-500' 
                 : 'text-secondary-300'
-            }`}
+            } tooltip-trigger`}
             data-post-title={post.data.title.toLowerCase()}
             data-post-tags={post.data.tags.join(' ').toLowerCase()}
             data-post-description={post.data.description.toLowerCase()}
@@ -125,7 +128,7 @@ const recentPosts = sortedPosts.slice(0, 5);
               {categoryPosts.map(post => (
                 <a 
                   href={`/blog/${post.slug}`}
-                  class={`post-link block p-2 text-sm rounded-lg transition-all duration-200 hover:bg-secondary-800/50 hover:text-accent-400 relative ${
+                  class={`post-link block p-2 text-sm rounded-lg transition-all duration-200 hover:bg-secondary-800/50 hover:text-accent-400 relative tooltip-trigger ${
                     currentSlug === post.slug 
                       ? 'bg-accent-500/20 text-accent-400 border-l-2 border-accent-500' 
                       : 'text-secondary-300'
@@ -133,7 +136,7 @@ const recentPosts = sortedPosts.slice(0, 5);
                   data-post-title={post.data.title.toLowerCase()}
                   data-post-tags={post.data.tags.join(' ').toLowerCase()}
                   data-post-description={post.data.description.toLowerCase()}
-                  title={post.data.title}
+                  data-tooltip={post.data.title}
                 >
                   <div class="truncate font-medium">{post.data.title}</div>
                   <div class="text-xs text-secondary-400 mt-1">
@@ -405,9 +408,9 @@ const recentPosts = sortedPosts.slice(0, 5);
     transform: translateX(12px);
     background: linear-gradient(135deg, #1a1a1a, #0a0a0a);
     color: #ffffff;
-    padding: 0.75rem 1rem;
+    padding: 1rem 1.25rem;
     border-radius: 0.5rem;
-    font-size: 0.875rem;
+    font-size: 1rem;
     font-weight: 500;
     z-index: 1000;
     border: 1px solid #666666;
@@ -416,7 +419,7 @@ const recentPosts = sortedPosts.slice(0, 5);
       0 10px 10px -5px rgba(0, 0, 0, 0.2),
       0 0 0 1px rgba(255, 255, 255, 0.05) inset;
     pointer-events: none;
-    max-width: 320px;
+    max-width: 400px;
     white-space: normal;
     text-align: left;
     line-height: 1.4;

--- a/src/components/BlogSidebar.astro
+++ b/src/components/BlogSidebar.astro
@@ -116,7 +116,7 @@ const recentPosts = sortedPosts.slice(0, 5);
                 stroke="currentColor" 
                 stroke-width="2" 
                 stroke-linecap="round" 
-                stroke-linejoin="round"
+                title={post.data.title}
               >
                 <polyline points="6 9 12 15 18 9"></polyline>
               </svg>
@@ -134,7 +134,7 @@ const recentPosts = sortedPosts.slice(0, 5);
                   data-post-title={post.data.title.toLowerCase()}
                   data-post-tags={post.data.tags.join(' ').toLowerCase()}
                   data-post-description={post.data.description.toLowerCase()}
-                  data-tooltip={post.data.title}
+                  title={post.data.title}
                 >
                   <div class="truncate font-medium">{post.data.title}</div>
                   <div class="text-xs text-secondary-400 mt-1">
@@ -450,7 +450,7 @@ const recentPosts = sortedPosts.slice(0, 5);
   /* Apply tooltip styles to specific elements */
   .post-link,
   .recent-post-link {
-    @apply tooltip-trigger;
+    position: relative;
   }
 
   @keyframes tooltipFadeIn {

--- a/src/components/BlogSidebar.astro
+++ b/src/components/BlogSidebar.astro
@@ -75,7 +75,7 @@ const recentPosts = sortedPosts.slice(0, RECENT_POSTS_LIMIT);
             data-post-title={post.data.title.toLowerCase()}
             data-post-tags={post.data.tags.join(' ').toLowerCase()}
             data-post-description={post.data.description.toLowerCase()}
-            data-tooltip={post.data.title}
+            title={post.data.title}
           >
             <div class="font-medium truncate">{post.data.title}</div>
             <div class="text-xs text-secondary-400 mt-1">


### PR DESCRIPTION
Adding onHover tooltip for blog articles on the left pane

## Summary by Sourcery

Implement on-hover tooltips for blog sidebar links and make recent posts count configurable via a RECENT_POSTS_LIMIT constant, while cleaning up old tooltip CSS.

New Features:
- Add on-hover tooltips to blog post links in the sidebar using the title attribute

Enhancements:
- Introduce RECENT_POSTS_LIMIT constant to configure the number of recent posts displayed

Chores:
- Remove legacy custom CSS tooltip styles and replace with native HTML title-based tooltips