### PR TITLE
Download

### DIFF
--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -154,20 +154,17 @@ releases.forEach((release, releaseIndex) => {
         </p>
         
         {latestAsset && (
-          <Button 
-            href={latestAsset.browser_download_url}
-            variant="primary"
-            size="lg"
-            download
-            class="inline-flex items-center gap-2"
+          <button
+            id="smartDownloadBtn"
+            class="bg-primary-500 hover:bg-primary-600 text-white px-8 py-3 rounded-md transition-colors duration-200 font-semibold text-lg inline-flex items-center gap-2"
           >
-            Download Latest Version
+            <span id="downloadText">Download Latest Version</span>
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
               <polyline points="7 10 12 15 17 10"></polyline>
               <line x1="12" y1="15" x2="12" y2="3"></line>
             </svg>
-          </Button>
+          </button>
         )}
       </div>
 
@@ -388,8 +385,87 @@ releases.forEach((release, releaseIndex) => {
   )}
 
   <!-- JavaScript for handling image clicks -->
-  <script define:vars={{ allReleaseImages, releaseImageMap: Object.fromEntries(releaseImageMap) }}>
+  <script define:vars={{ allReleaseImages, releaseImageMap: Object.fromEntries(releaseImageMap), releases }}>
     document.addEventListener('DOMContentLoaded', function() {
+      // OS Detection and Smart Download
+      function detectOS() {
+        const userAgent = navigator.userAgent.toLowerCase();
+        const platform = navigator.platform.toLowerCase();
+        
+        if (userAgent.includes('win') || platform.includes('win')) {
+          return 'windows';
+        } else if (userAgent.includes('mac') || platform.includes('mac')) {
+          return 'macos';
+        } else if (userAgent.includes('linux') || platform.includes('linux')) {
+          return 'linux';
+        }
+        
+        return 'windows'; // Default fallback
+      }
+      
+      function setupSmartDownload() {
+        const downloadBtn = document.getElementById('smartDownloadBtn');
+        const downloadText = document.getElementById('downloadText');
+        
+        if (!downloadBtn || !releases || releases.length === 0) return;
+        
+        const latestRelease = releases[0];
+        if (!latestRelease || !latestRelease.assets) return;
+        
+        const userOS = detectOS();
+        let selectedAsset = null;
+        let osDisplayName = '';
+        
+        // Find the appropriate asset based on OS
+        for (const asset of latestRelease.assets) {
+          const fileName = asset.name.toLowerCase();
+          
+          if (userOS === 'windows' && (fileName.includes('.exe') || fileName.includes('windows') || fileName.includes('win'))) {
+            selectedAsset = asset;
+            osDisplayName = 'Windows';
+            break;
+          } else if (userOS === 'macos' && (fileName.includes('.dmg') || fileName.includes('mac') || fileName.includes('darwin'))) {
+            selectedAsset = asset;
+            osDisplayName = 'macOS';
+            break;
+          } else if (userOS === 'linux' && (fileName.includes('.appimage') || fileName.includes('linux') || fileName.includes('.deb') || fileName.includes('.rpm'))) {
+            selectedAsset = asset;
+            osDisplayName = 'Linux';
+            break;
+          }
+        }
+        
+        // Fallback to first available asset if no OS-specific match found
+        if (!selectedAsset && latestRelease.assets.length > 0) {
+          selectedAsset = latestRelease.assets[0];
+          osDisplayName = '';
+        }
+        
+        if (selectedAsset) {
+          // Update button text to show detected OS
+          if (osDisplayName) {
+            downloadText.textContent = `Download for ${osDisplayName}`;
+          }
+          
+          // Set up click handler
+          downloadBtn.addEventListener('click', function() {
+            // Create a temporary link and click it to trigger download
+            const link = document.createElement('a');
+            link.href = selectedAsset.browser_download_url;
+            link.download = selectedAsset.name;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+          });
+          
+          // Add hover effect to show file name
+          downloadBtn.title = `Download ${selectedAsset.name}`;
+        }
+      }
+      
+      // Initialize smart download
+      setupSmartDownload();
+      
       // Handle clicks on release images
       document.querySelectorAll('[data-release-screenshot]').forEach(img => {
         img.addEventListener('click', function() {

--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -530,13 +530,15 @@ releases.forEach((release, releaseIndex) => {
           const releaseIndex = parseInt(this.getAttribute('data-release-index') || '0');
           const imageIndex = parseInt(this.getAttribute('data-image-index') || '0');
           
-          // Calculate the global index for this image
-          let globalIndex = 0;
-          for (let i = 0; i < releaseIndex; i++) {
-            const images = releaseImageMap.get(i) || [];
-            globalIndex += images.length;
-          }
-          globalIndex += imageIndex;
+          // Calculate the global index by finding all previous images
+          let globalIndex = imageIndex;
+          const allPreviousImages = document.querySelectorAll(`[data-release-screenshot][data-release-index]`);
+          Array.from(allPreviousImages).forEach(prevImg => {
+            const prevReleaseIndex = parseInt((prevImg as HTMLElement).getAttribute('data-release-index') || '0');
+            if (prevReleaseIndex < releaseIndex) {
+              globalIndex++;
+            }
+          });
           
           // Trigger the image viewer
           const viewer = document.getElementById('imageViewerReleases');

--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -521,6 +521,7 @@ releases.forEach((release, releaseIndex) => {
       }
       
       // Initialize download modal
+      setupDownloadModal();
       
       // Handle clicks on release images
       document.querySelectorAll('[data-release-screenshot]').forEach(img => {

--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -155,10 +155,10 @@ releases.forEach((release, releaseIndex) => {
         
         {latestAsset && (
           <button
-            id="smartDownloadBtn"
+            id="downloadBtn"
             class="bg-primary-500 hover:bg-primary-600 text-white px-8 py-3 rounded-md transition-colors duration-200 font-semibold text-lg inline-flex items-center gap-2"
           >
-            <span id="downloadText">Download Latest Version</span>
+            <span>Download Latest Version</span>
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
               <polyline points="7 10 12 15 17 10"></polyline>
@@ -379,6 +379,26 @@ releases.forEach((release, releaseIndex) => {
     </div>
   </section>
 
+  <!-- Download Options Modal -->
+  <div id="downloadModal" class="fixed inset-0 z-50 hidden bg-black/50 backdrop-blur-sm">
+    <div class="flex items-center justify-center min-h-screen p-4">
+      <div class="bg-secondary-900 border border-secondary-700 rounded-lg p-6 max-w-md w-full">
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-xl font-bold text-white">Choose Your Platform</h3>
+          <button id="closeModal" class="text-secondary-400 hover:text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+        <div id="downloadOptions" class="space-y-3">
+          <!-- Download options will be populated by JavaScript -->
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Image Viewer Component for Releases -->
   {allReleaseImages.length > 0 && (
     <ImageViewerReleases images={allReleaseImages} />
@@ -387,84 +407,121 @@ releases.forEach((release, releaseIndex) => {
   <!-- JavaScript for handling image clicks -->
   <script define:vars={{ allReleaseImages, releaseImageMap: Object.fromEntries(releaseImageMap), releases }}>
     document.addEventListener('DOMContentLoaded', function() {
-      // OS Detection and Smart Download
-      function detectOS() {
-        const userAgent = navigator.userAgent.toLowerCase();
-        const platform = navigator.platform.toLowerCase();
+      // Download Modal Setup
+      function setupDownloadModal() {
+        const downloadBtn = document.getElementById('downloadBtn');
+        const modal = document.getElementById('downloadModal');
+        const closeModal = document.getElementById('closeModal');
+        const downloadOptions = document.getElementById('downloadOptions');
         
-        if (userAgent.includes('win') || platform.includes('win')) {
-          return 'windows';
-        } else if (userAgent.includes('mac') || platform.includes('mac')) {
-          return 'macos';
-        } else if (userAgent.includes('linux') || platform.includes('linux')) {
-          return 'linux';
-        }
-        
-        return 'windows'; // Default fallback
-      }
-      
-      function setupSmartDownload() {
-        const downloadBtn = document.getElementById('smartDownloadBtn');
-        const downloadText = document.getElementById('downloadText');
-        
-        if (!downloadBtn || !releases || releases.length === 0) return;
+        if (!downloadBtn || !modal || !releases || releases.length === 0) return;
         
         const latestRelease = releases[0];
         if (!latestRelease || !latestRelease.assets) return;
         
-        const userOS = detectOS();
-        let selectedAsset = null;
-        let osDisplayName = '';
-        
-        // Find the appropriate asset based on OS
-        for (const asset of latestRelease.assets) {
-          const fileName = asset.name.toLowerCase();
+        // Function to get platform info from filename
+        function getPlatformInfo(filename) {
+          const lowerName = filename.toLowerCase();
           
-          if (userOS === 'windows' && (fileName.includes('.exe') || fileName.includes('windows') || fileName.includes('win'))) {
-            selectedAsset = asset;
-            osDisplayName = 'Windows';
-            break;
-          } else if (userOS === 'macos' && (fileName.includes('.dmg') || fileName.includes('mac') || fileName.includes('darwin'))) {
-            selectedAsset = asset;
-            osDisplayName = 'macOS';
-            break;
-          } else if (userOS === 'linux' && (fileName.includes('.appimage') || fileName.includes('linux') || fileName.includes('.deb') || fileName.includes('.rpm'))) {
-            selectedAsset = asset;
-            osDisplayName = 'Linux';
-            break;
+          if (lowerName.includes('.exe') || lowerName.includes('windows') || lowerName.includes('win')) {
+            return {
+              platform: 'Windows',
+              icon: 'bi-windows',
+              color: 'text-blue-400'
+            };
+          } else if (lowerName.includes('.dmg') || lowerName.includes('mac') || lowerName.includes('darwin')) {
+            return {
+              platform: 'macOS',
+              icon: 'bi-apple',
+              color: 'text-gray-300'
+            };
+          } else if (lowerName.includes('.appimage') || lowerName.includes('linux') || lowerName.includes('.deb') || lowerName.includes('.rpm')) {
+            return {
+              platform: 'Linux',
+              icon: 'bi-ubuntu',
+              color: 'text-orange-400'
+            };
+          } else {
+            return {
+              platform: 'Other',
+              icon: 'bi-download',
+              color: 'text-secondary-400'
+            };
           }
         }
         
-        // Fallback to first available asset if no OS-specific match found
-        if (!selectedAsset && latestRelease.assets.length > 0) {
-          selectedAsset = latestRelease.assets[0];
-          osDisplayName = '';
-        }
+        // Populate download options
+        downloadOptions.innerHTML = latestRelease.assets.map(asset => {
+          const platformInfo = getPlatformInfo(asset.name);
+          return `
+            <a
+              href="${asset.browser_download_url}"
+              class="flex items-center justify-between bg-secondary-800 hover:bg-secondary-700 transition-colors p-4 rounded-lg group"
+              download="${asset.name}"
+            >
+              <div class="flex items-center gap-3">
+                <div class="${platformInfo.color}">
+                  <i class="${platformInfo.icon} text-2xl"></i>
+                </div>
+                <div>
+                  <div class="font-semibold text-white">${platformInfo.platform}</div>
+                  <div class="text-sm text-secondary-400">${asset.name}</div>
+                </div>
+              </div>
+              <div class="flex items-center gap-2 text-secondary-400">
+                <span class="text-xs">${asset.download_count.toLocaleString()} downloads</span>
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="group-hover:translate-x-1 transition-transform duration-200">
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                  <polyline points="7 10 12 15 17 10"></polyline>
+                  <line x1="12" y1="15" x2="12" y2="3"></line>
+                </svg>
+              </div>
+            </a>
+          `;
+        }).join('');
         
-        if (selectedAsset) {
-          // Update button text to show detected OS
-          if (osDisplayName) {
-            downloadText.textContent = `Download for ${osDisplayName}`;
+        // Show modal when download button is clicked
+        downloadBtn.addEventListener('click', function() {
+          modal.classList.remove('hidden');
+          document.body.style.overflow = 'hidden';
+        });
+        
+        // Hide modal when close button is clicked
+        closeModal.addEventListener('click', function() {
+          modal.classList.add('hidden');
+          document.body.style.overflow = '';
+        });
+        
+        // Hide modal when clicking outside
+        modal.addEventListener('click', function(e) {
+          if (e.target === modal) {
+            modal.classList.add('hidden');
+            document.body.style.overflow = '';
           }
-          
-          // Set up click handler
-          downloadBtn.addEventListener('click', function() {
-            // Create a temporary link and click it to trigger download
-            const link = document.createElement('a');
-            link.href = selectedAsset.browser_download_url;
-            link.download = selectedAsset.name;
-            document.body.appendChild(link);
-            link.click();
-            document.body.removeChild(link);
-          });
-          
-          // Add hover effect to show file name
-          downloadBtn.title = `Download ${selectedAsset.name}`;
+        });
+        
+        // Hide modal on escape key
+        document.addEventListener('keydown', function(e) {
+          if (e.key === 'Escape' && !modal.classList.contains('hidden')) {
+            modal.classList.add('hidden');
+            document.body.style.overflow = '';
+          }
+        });
+        
+        // Close modal when a download link is clicked
+        downloadOptions.addEventListener('click', function(e) {
+          if (e.target.closest('a')) {
+            setTimeout(() => {
+              modal.classList.add('hidden');
+              document.body.style.overflow = '';
+            }, 100);
+          }
+        });
         }
       }
       
-      // Initialize smart download
-      setupSmartDownload();
+      // Initialize download modal
+      setupDownloadModal();
       
       // Handle clicks on release images
       document.querySelectorAll('[data-release-screenshot]').forEach(img => {

--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -533,8 +533,8 @@ releases.forEach((release, releaseIndex) => {
           // Calculate the global index for this image
           let globalIndex = 0;
           for (let i = 0; i < releaseIndex; i++) {
-            const releaseImages = releaseImageMap.get(i) || [];
-            globalIndex += releaseImages.length;
+            const images = releaseImageMap.get(i) || [];
+            globalIndex += images.length;
           }
           globalIndex += imageIndex;
           

--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -130,7 +130,7 @@ const latestRelease = releases[0];
 
 // Extract all images from all releases for the ImageViewer
 const allReleaseImages: Array<{url: string, alt: string, description?: string}> = [];
-const releaseImageMap: Map<number, Array<{url: string, alt: string, description?: string}>> = new Map();
+const releaseImageMap = new Map<number, Array<{url: string, alt: string, description?: string}>>();
 
 releases.forEach((release, releaseIndex) => {
   const images = extractImagesFromMarkdown(release.body);
@@ -413,7 +413,7 @@ releases.forEach((release, releaseIndex) => {
       if (!downloadBtn || !modal) return;
       
       // Get platform info function
-      function getPlatformInfo(filename) {
+      function getPlatformInfo(filename: string) {
         const lowerName = filename.toLowerCase();
         
         if (lowerName.includes('.exe') || lowerName.includes('windows') || lowerName.includes('win')) {
@@ -450,7 +450,7 @@ releases.forEach((release, releaseIndex) => {
           const release = await response.json();
           
           if (release.assets && release.assets.length > 0) {
-            downloadOptions.innerHTML = release.assets.map(asset => {
+            downloadOptions!.innerHTML = release.assets.map((asset: any) => {
               const platformInfo = getPlatformInfo(asset.name);
               return `
                 <a
@@ -481,7 +481,7 @@ releases.forEach((release, releaseIndex) => {
           }
         } catch (error) {
           console.error('Error fetching release data:', error);
-          downloadOptions.innerHTML = '<p class="text-secondary-400 text-center">Error loading download options</p>';
+          downloadOptions!.innerHTML = '<p class="text-secondary-400 text-center">Error loading download options</p>';
         }
       }
       
@@ -493,7 +493,7 @@ releases.forEach((release, releaseIndex) => {
       });
       
       // Hide modal when close button is clicked
-      closeModal.addEventListener('click', function() {
+      closeModal?.addEventListener('click', function() {
         modal.classList.add('hidden');
         document.body.style.overflow = '';
       });
@@ -515,7 +515,7 @@ releases.forEach((release, releaseIndex) => {
       });
       
       // Close modal when a download link is clicked
-      downloadOptions.addEventListener('click', function(e) {
+      downloadOptions?.addEventListener('click', function(e) {
         if (e.target.closest('a')) {
           setTimeout(() => {
             modal.classList.add('hidden');
@@ -533,7 +533,7 @@ releases.forEach((release, releaseIndex) => {
           // Calculate the global index for this image
           let globalIndex = 0;
           for (let i = 0; i < releaseIndex; i++) {
-            const releaseImages = releaseImageMap[i] || [];
+            const releaseImages = releaseImageMap.get(i) || [];
             globalIndex += releaseImages.length;
           }
           globalIndex += imageIndex;

--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -521,7 +521,6 @@ releases.forEach((release, releaseIndex) => {
       }
       
       // Initialize download modal
-      setupDownloadModal();
       
       // Handle clicks on release images
       document.querySelectorAll('[data-release-screenshot]').forEach(img => {

--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -515,8 +515,8 @@ releases.forEach((release, releaseIndex) => {
       });
       
       // Close modal when a download link is clicked
-      downloadOptions?.addEventListener('click', function(e) {
-        if (e.target.closest('a')) {
+      downloadOptions?.addEventListener('click', function(e: Event) {
+        if (e.target && (e.target as HTMLElement).closest('a')) {
           setTimeout(() => {
             modal.classList.add('hidden');
             document.body.style.overflow = '';
@@ -533,8 +533,8 @@ releases.forEach((release, releaseIndex) => {
           // Calculate the global index for this image
           let globalIndex = 0;
           for (let i = 0; i < releaseIndex; i++) {
-            const images = releaseImageMap.get(i) || [];
-            globalIndex += images.length;
+            const releaseImages = releaseImageMap.get(i) || [];
+            globalIndex += releaseImages.length;
           }
           globalIndex += imageIndex;
           

--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -444,14 +444,24 @@ releases.forEach((release, releaseIndex) => {
       }
       
       // Fetch latest release data and populate modal
-      async function setupModal() {
+      // Cache for release data
+      let cachedReleaseData: any = null;
+      let isReleaseDataLoaded = false;
+
+      async function setupModal(): Promise<any> {
         try {
           const response = await fetch('https://api.github.com/repos/ashwin-nat/pits-n-giggles/releases/latest');
+          
+          if (!response.ok) {
+            throw new Error(`GitHub API returned ${response.status}: ${response.statusText}`);
+          }
+          
           const release = await response.json();
           
           if (release.assets && release.assets.length > 0) {
-            downloadOptions!.innerHTML = release.assets.map((asset: any) => {
+            const modalContent = release.assets.map((asset: any) => {
               const platformInfo = getPlatformInfo(asset.name);
+              const downloadCount = asset.download_count || 0;
               return `
                 <a
                   href="${asset.browser_download_url}"
@@ -468,7 +478,7 @@ releases.forEach((release, releaseIndex) => {
                     </div>
                   </div>
                   <div class="flex items-center gap-2 text-secondary-400">
-                    <span class="text-xs">${asset.download_count.toLocaleString()} downloads</span>
+                    <span class="text-xs">${downloadCount.toLocaleString()} downloads</span>
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="group-hover:translate-x-1 transition-transform duration-200">
                       <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
                       <polyline points="7 10 12 15 17 10"></polyline>
@@ -478,10 +488,51 @@ releases.forEach((release, releaseIndex) => {
                 </a>
               `;
             }).join('');
+            
+            downloadOptions!.innerHTML = modalContent;
+            return release;
           }
         } catch (error) {
           console.error('Error fetching release data:', error);
           downloadOptions!.innerHTML = '<p class="text-secondary-400 text-center">Error loading download options</p>';
+          throw error;
+        }
+      }
+      
+      // Helper to populate modal with cached data
+      function populateModalWithReleaseData(release: any) {
+        if (release && release.assets && release.assets.length > 0) {
+          const modalContent = release.assets.map((asset: any) => {
+            const platformInfo = getPlatformInfo(asset.name);
+            const downloadCount = asset.download_count || 0;
+            return `
+              <a
+                href="${asset.browser_download_url}"
+                class="flex items-center justify-between bg-secondary-800 hover:bg-secondary-700 transition-colors p-4 rounded-lg group"
+                download="${asset.name}"
+              >
+                <div class="flex items-center gap-3">
+                  <div class="${platformInfo.color}">
+                    <i class="${platformInfo.icon} text-2xl"></i>
+                  </div>
+                  <div>
+                    <div class="font-semibold text-white">${platformInfo.platform}</div>
+                    <div class="text-sm text-secondary-400">${asset.name}</div>
+                  </div>
+                </div>
+                <div class="flex items-center gap-2 text-secondary-400">
+                  <span class="text-xs">${downloadCount.toLocaleString()} downloads</span>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="group-hover:translate-x-1 transition-transform duration-200">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                    <polyline points="7 10 12 15 17 10"></polyline>
+                    <line x1="12" y1="15" x2="12" y2="3"></line>
+                  </svg>
+                </div>
+              </a>
+            `;
+          }).join('');
+          
+          downloadOptions!.innerHTML = modalContent;
         }
       }
       
@@ -489,7 +540,18 @@ releases.forEach((release, releaseIndex) => {
       downloadBtn.addEventListener('click', function() {
         modal.classList.remove('hidden');
         document.body.style.overflow = 'hidden';
-        setupModal();
+        
+        if (!isReleaseDataLoaded) {
+          setupModal().then((data) => {
+            cachedReleaseData = data;
+            isReleaseDataLoaded = true;
+          }).catch((error) => {
+            console.error('Failed to load release data:', error);
+          });
+        } else {
+          // Use cached data to populate modal
+          populateModalWithReleaseData(cachedReleaseData);
+        }
       });
       
       // Hide modal when close button is clicked

--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -526,15 +526,15 @@ releases.forEach((release, releaseIndex) => {
       
       // Handle clicks on release images
       document.querySelectorAll('[data-release-screenshot]').forEach(img => {
-        img.addEventListener('click', function() {
-          const releaseIndex = parseInt(this.getAttribute('data-release-index'));
-          const imageIndex = parseInt(this.getAttribute('data-image-index'));
+        img.addEventListener('click', function(this: HTMLElement) {
+          const releaseIndex = parseInt(this.getAttribute('data-release-index') || '0');
+          const imageIndex = parseInt(this.getAttribute('data-image-index') || '0');
           
           // Calculate the global index for this image
           let globalIndex = 0;
           for (let i = 0; i < releaseIndex; i++) {
-            const releaseImages = releaseImageMap.get(i) || [];
-            globalIndex += releaseImages.length;
+            const images = releaseImageMap.get(i) || [];
+            globalIndex += images.length;
           }
           globalIndex += imageIndex;
           

--- a/src/pages/releases.astro
+++ b/src/pages/releases.astro
@@ -127,7 +127,6 @@ function parseMarkdownWithoutImages(content: string | undefined): string {
 // Get the releases data
 const releases: GitHubRelease[] = await getGitHubReleases();
 const latestRelease = releases[0];
-const latestAsset = latestRelease?.assets?.find(a => a.browser_download_url.includes("pits_n_giggles"));
 
 // Extract all images from all releases for the ImageViewer
 const allReleaseImages: Array<{url: string, alt: string, description?: string}> = [];
@@ -153,7 +152,7 @@ releases.forEach((release, releaseIndex) => {
           Stay up to date with the latest versions and improvements to Pits n' Giggles. Each release brings new features, bug fixes, and performance enhancements.
         </p>
         
-        {latestAsset && (
+        {latestRelease && latestRelease.assets && latestRelease.assets.length > 0 && (
           <button
             id="downloadBtn"
             class="bg-primary-500 hover:bg-primary-600 text-white px-8 py-3 rounded-md transition-colors duration-200 font-semibold text-lg inline-flex items-center gap-2"
@@ -404,124 +403,126 @@ releases.forEach((release, releaseIndex) => {
     <ImageViewerReleases images={allReleaseImages} />
   )}
 
-  <!-- JavaScript for handling image clicks -->
-  <script define:vars={{ allReleaseImages, releaseImageMap: Object.fromEntries(releaseImageMap), releases }}>
+  <script>
     document.addEventListener('DOMContentLoaded', function() {
-      // Download Modal Setup
-      function setupDownloadModal() {
-        const downloadBtn = document.getElementById('downloadBtn');
-        const modal = document.getElementById('downloadModal');
-        const closeModal = document.getElementById('closeModal');
-        const downloadOptions = document.getElementById('downloadOptions');
+      const downloadBtn = document.getElementById('downloadBtn');
+      const modal = document.getElementById('downloadModal');
+      const closeModal = document.getElementById('closeModal');
+      const downloadOptions = document.getElementById('downloadOptions');
+      
+      if (!downloadBtn || !modal) return;
+      
+      // Get platform info function
+      function getPlatformInfo(filename) {
+        const lowerName = filename.toLowerCase();
         
-        if (!downloadBtn || !modal || !releases || releases.length === 0) return;
-        
-        const latestRelease = releases[0];
-        if (!latestRelease || !latestRelease.assets) return;
-        
-        // Function to get platform info from filename
-        function getPlatformInfo(filename) {
-          const lowerName = filename.toLowerCase();
-          
-          if (lowerName.includes('.exe') || lowerName.includes('windows') || lowerName.includes('win')) {
-            return {
-              platform: 'Windows',
-              icon: 'bi-windows',
-              color: 'text-blue-400'
-            };
-          } else if (lowerName.includes('.dmg') || lowerName.includes('mac') || lowerName.includes('darwin')) {
-            return {
-              platform: 'macOS',
-              icon: 'bi-apple',
-              color: 'text-gray-300'
-            };
-          } else if (lowerName.includes('.appimage') || lowerName.includes('linux') || lowerName.includes('.deb') || lowerName.includes('.rpm')) {
-            return {
-              platform: 'Linux',
-              icon: 'bi-ubuntu',
-              color: 'text-orange-400'
-            };
-          } else {
-            return {
-              platform: 'Other',
-              icon: 'bi-download',
-              color: 'text-secondary-400'
-            };
-          }
-        }
-        
-        // Populate download options
-        downloadOptions.innerHTML = latestRelease.assets.map(asset => {
-          const platformInfo = getPlatformInfo(asset.name);
-          return `
-            <a
-              href="${asset.browser_download_url}"
-              class="flex items-center justify-between bg-secondary-800 hover:bg-secondary-700 transition-colors p-4 rounded-lg group"
-              download="${asset.name}"
-            >
-              <div class="flex items-center gap-3">
-                <div class="${platformInfo.color}">
-                  <i class="${platformInfo.icon} text-2xl"></i>
-                </div>
-                <div>
-                  <div class="font-semibold text-white">${platformInfo.platform}</div>
-                  <div class="text-sm text-secondary-400">${asset.name}</div>
-                </div>
-              </div>
-              <div class="flex items-center gap-2 text-secondary-400">
-                <span class="text-xs">${asset.download_count.toLocaleString()} downloads</span>
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="group-hover:translate-x-1 transition-transform duration-200">
-                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                  <polyline points="7 10 12 15 17 10"></polyline>
-                  <line x1="12" y1="15" x2="12" y2="3"></line>
-                </svg>
-              </div>
-            </a>
-          `;
-        }).join('');
-        
-        // Show modal when download button is clicked
-        downloadBtn.addEventListener('click', function() {
-          modal.classList.remove('hidden');
-          document.body.style.overflow = 'hidden';
-        });
-        
-        // Hide modal when close button is clicked
-        closeModal.addEventListener('click', function() {
-          modal.classList.add('hidden');
-          document.body.style.overflow = '';
-        });
-        
-        // Hide modal when clicking outside
-        modal.addEventListener('click', function(e) {
-          if (e.target === modal) {
-            modal.classList.add('hidden');
-            document.body.style.overflow = '';
-          }
-        });
-        
-        // Hide modal on escape key
-        document.addEventListener('keydown', function(e) {
-          if (e.key === 'Escape' && !modal.classList.contains('hidden')) {
-            modal.classList.add('hidden');
-            document.body.style.overflow = '';
-          }
-        });
-        
-        // Close modal when a download link is clicked
-        downloadOptions.addEventListener('click', function(e) {
-          if (e.target.closest('a')) {
-            setTimeout(() => {
-              modal.classList.add('hidden');
-              document.body.style.overflow = '';
-            }, 100);
-          }
-        });
+        if (lowerName.includes('.exe') || lowerName.includes('windows') || lowerName.includes('win')) {
+          return {
+            platform: 'Windows',
+            icon: 'bi-windows',
+            color: 'text-blue-400'
+          };
+        } else if (lowerName.includes('.dmg') || lowerName.includes('mac') || lowerName.includes('darwin')) {
+          return {
+            platform: 'macOS',
+            icon: 'bi-apple',
+            color: 'text-gray-300'
+          };
+        } else if (lowerName.includes('.appimage') || lowerName.includes('linux') || lowerName.includes('.deb') || lowerName.includes('.rpm')) {
+          return {
+            platform: 'Linux',
+            icon: 'bi-ubuntu',
+            color: 'text-orange-400'
+          };
+        } else {
+          return {
+            platform: 'Other',
+            icon: 'bi-download',
+            color: 'text-secondary-400'
+          };
         }
       }
       
-      // Initialize download modal
-      setupDownloadModal();
+      // Fetch latest release data and populate modal
+      async function setupModal() {
+        try {
+          const response = await fetch('https://api.github.com/repos/ashwin-nat/pits-n-giggles/releases/latest');
+          const release = await response.json();
+          
+          if (release.assets && release.assets.length > 0) {
+            downloadOptions.innerHTML = release.assets.map(asset => {
+              const platformInfo = getPlatformInfo(asset.name);
+              return `
+                <a
+                  href="${asset.browser_download_url}"
+                  class="flex items-center justify-between bg-secondary-800 hover:bg-secondary-700 transition-colors p-4 rounded-lg group"
+                  download="${asset.name}"
+                >
+                  <div class="flex items-center gap-3">
+                    <div class="${platformInfo.color}">
+                      <i class="${platformInfo.icon} text-2xl"></i>
+                    </div>
+                    <div>
+                      <div class="font-semibold text-white">${platformInfo.platform}</div>
+                      <div class="text-sm text-secondary-400">${asset.name}</div>
+                    </div>
+                  </div>
+                  <div class="flex items-center gap-2 text-secondary-400">
+                    <span class="text-xs">${asset.download_count.toLocaleString()} downloads</span>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="group-hover:translate-x-1 transition-transform duration-200">
+                      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                      <polyline points="7 10 12 15 17 10"></polyline>
+                      <line x1="12" y1="15" x2="12" y2="3"></line>
+                    </svg>
+                  </div>
+                </a>
+              `;
+            }).join('');
+          }
+        } catch (error) {
+          console.error('Error fetching release data:', error);
+          downloadOptions.innerHTML = '<p class="text-secondary-400 text-center">Error loading download options</p>';
+        }
+      }
+      
+      // Show modal when download button is clicked
+      downloadBtn.addEventListener('click', function() {
+        modal.classList.remove('hidden');
+        document.body.style.overflow = 'hidden';
+        setupModal();
+      });
+      
+      // Hide modal when close button is clicked
+      closeModal.addEventListener('click', function() {
+        modal.classList.add('hidden');
+        document.body.style.overflow = '';
+      });
+      
+      // Hide modal when clicking outside
+      modal.addEventListener('click', function(e) {
+        if (e.target === modal) {
+          modal.classList.add('hidden');
+          document.body.style.overflow = '';
+        }
+      });
+      
+      // Hide modal on escape key
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape' && !modal.classList.contains('hidden')) {
+          modal.classList.add('hidden');
+          document.body.style.overflow = '';
+        }
+      });
+      
+      // Close modal when a download link is clicked
+      downloadOptions.addEventListener('click', function(e) {
+        if (e.target.closest('a')) {
+          setTimeout(() => {
+            modal.classList.add('hidden');
+            document.body.style.overflow = '';
+          }, 100);
+        }
+      });
       
       // Handle clicks on release images
       document.querySelectorAll('[data-release-screenshot]').forEach(img => {
@@ -540,7 +541,6 @@ releases.forEach((release, releaseIndex) => {
           // Trigger the image viewer
           const viewer = document.getElementById('imageViewerReleases');
           if (viewer) {
-            // Dispatch a custom event to open the viewer
             const event = new CustomEvent('openImageViewerReleases', { 
               detail: { index: globalIndex } 
             });


### PR DESCRIPTION
Add a modal asking for OS choice in downloads page when clicking download latest version

## Summary by Sourcery

Replace the direct download link with a modal that lets users choose their platform-specific installer by fetching and categorizing assets from the latest GitHub release, and improve the image viewer indexing logic.

New Features:
- Introduce a download button that opens a modal for selecting OS-specific assets
- Fetch and display latest release assets in the modal with platform icons and download counts

Enhancements:
- Refine logic for calculating global image index in the release image viewer